### PR TITLE
checkrt: Sort symbols

### DIFF
--- a/checkrt.c
+++ b/checkrt.c
@@ -61,7 +61,7 @@ void checkrt(char *usr_in_appdir)
 
     char *stdcxx_bundle_lib = "./" CXXDIR "/libstdc++.so.6";
     char *gcc_bundle_lib = "./" GCCDIR "/libgcc_s.so.1";
-    const char *format = "tr '\\0' '\\n' < '%s' | grep -e '%s' | tail -n1";
+    const char *format = "tr '\\0' '\\n' < '%s' | grep -e '%s' | awk '{ print length, bash }' | sort | tail -n1 | awk 'NR==1{print $NF}'";
 
     if (access(stdcxx_bundle_lib, F_OK) == 0) {
         f = popen("PATH=\"/sbin:$PATH\" ldconfig -p | grep 'libstdc++.so.6 (" LIBC6_ARCH ")' | awk 'NR==1{print $NF}'", "r");


### PR DESCRIPTION
Some systems have out-of-order symbols in libstdc++, which fools the old logic into thinking the installed libstdc++ library is older than the included version. This causes problems with host libraries that need a newer libstdc++ library.

Sort the symbols found in the library and use the last one.